### PR TITLE
fix(ansible): add/remove privilege escalation on local tasks

### DIFF
--- a/.github/scripts/packer_build.sh
+++ b/.github/scripts/packer_build.sh
@@ -32,5 +32,5 @@ cat "$PACKER_FILE"
 
 packer init "$PACKER_FILE"
 
-# Since packer build fails randomly because of external resources use, retry packer buid until it succeeds
+# Since packer build fails randomly because of external resources use, retry packer build until it succeeds
 timeout 30m bash -c "until packer build $PACKER_FILE; do sleep 30; done"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -18,8 +18,8 @@ export USERNAME=cosmian
 export HOST=35.204.83.49
 # Be sure to install deps: `pip install -r python_modules.txt` on your localhost
 cd ansible
-ansible-playbook cosmian_vm_playbook.yml -i ${HOST}, -u $USERNAME -e cosmian_vm_version=1.1.1
-ansible-playbook kms_playbook.yml -i ${HOST}, -u $USERNAME -e cosmian_vm_version=1.1.1 -e cosmian_kms_version=4.15.0
+ansible-playbook cosmian-vm-playbook.yml -i ${HOST}, -u $USERNAME -e cosmian_vm_version=1.1.1
+ansible-playbook kms-playbook.yml -i ${HOST}, -u $USERNAME -e cosmian_vm_version=1.1.1 -e cosmian_kms_version=4.15.0
 ```
 
 The machine has been configured

--- a/ansible/roles/check_cosmian_vm/tasks/main.yml
+++ b/ansible/roles/check_cosmian_vm/tasks/main.yml
@@ -30,7 +30,6 @@
       rm -f /tmp/cosmian_vm
       rm -f ./cosmian_vm.snapshot
   delegate_to: localhost
-  become: false
 
 - name: Download Cosmian VM CLI
   ansible.builtin.get_url:
@@ -116,4 +115,3 @@
       rm -f /tmp/cosmian_vm
       rm -f ./cosmian_vm.snapshot
   delegate_to: localhost
-  become: false

--- a/ansible/roles/start_kms/tasks/main.yml
+++ b/ansible/roles/start_kms/tasks/main.yml
@@ -14,7 +14,6 @@
     cmd: |
       rm -f /tmp/cosmian_vm
   delegate_to: localhost
-  become: false
 
 - name: Download Cosmian VM CLI
   ansible.builtin.get_url:
@@ -22,6 +21,7 @@
     dest: /tmp/
     mode: "u+x"
   delegate_to: localhost
+  become: false
 
 - name: Copy KMS configuration
   ansible.builtin.template:
@@ -29,6 +29,7 @@
     dest: /tmp/kms.toml
     mode: "0644"
   delegate_to: localhost
+  become: false
 
 - name: Cosmian VM App initialization
   ansible.builtin.command:
@@ -130,4 +131,3 @@
     cmd: |
       rm -f /tmp/cosmian_vm
   delegate_to: localhost
-  become: false


### PR DESCRIPTION
Ansible for KMS installation:
- fix privilege escalation on local tasks
  - always clean local tmp file on sudo  
- update ansible doc

Rust changes:
- update h2 (cargo audit)