### PR TITLE
feat: make KMS/AI images usable even if KMS/AI have not been configured

### DIFF
--- a/.github/scripts/gcp-new-instance.sh
+++ b/.github/scripts/gcp-new-instance.sh
@@ -37,25 +37,25 @@ if [ "$TECHNO" = "tdx" ]; then
     --metadata=ssh-keys="cosmian:$SSH_PUB_KEY"
 else
   if [ "$DISTRIB" = "ubuntu" ]; then
-    # Ubuntu SEV
-    IMAGE="ubuntu-2404-noble-amd64-v20240523a"
-    IMAGE_PROJECT="ubuntu-os-cloud"
     # Cosmian Ubuntu SEV
     IMAGE="base-image-0-1-5-ubuntu-sev"
     IMAGE_PROJECT="cosmian-dev"
     # Cosmian KMS Ubuntu SEV
     IMAGE="cosmian-vm-1-2-5-kms-4-17-0-sev-ubuntu"
     IMAGE_PROJECT="cosmian-dev"
+    # Ubuntu SEV
+    IMAGE="ubuntu-2404-noble-amd64-v20240523a"
+    IMAGE_PROJECT="ubuntu-os-cloud"
   else
-    # RHEL SEV
-    IMAGE="rhel-9-v20240515"
-    IMAGE_PROJECT="rhel-cloud"
     # Cosmian Ubuntu SEV
     IMAGE="base-image-0-1-5-rhel-sev"
     IMAGE_PROJECT="cosmian-dev"
     # Cosmian Ubuntu SEV
     IMAGE="cosmian-vm-1-2-5-kms-4-17-0-sev-rhel"
     IMAGE_PROJECT="cosmian-dev"
+    # RHEL SEV
+    IMAGE="rhel-9-v20240515"
+    IMAGE_PROJECT="rhel-cloud"
   fi
   gcloud beta compute instances create "$NAME" \
     --machine-type n2d-standard-2 \

--- a/ansible/roles/ai_runner/tasks/main.yml
+++ b/ansible/roles/ai_runner/tasks/main.yml
@@ -56,6 +56,22 @@
     group: root
     mode: "0644"
 
+- name: Create the directory /var/lib/cosmian_vm/data/app if it does not exist
+  ansible.builtin.file:
+    path: /var/lib/cosmian_vm/data/app
+    state: directory
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Create default Cosmian AI Runner configuration
+  ansible.builtin.template:
+    src: config.json.j2
+    dest: /var/lib/cosmian_vm/data/app/app.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Create the directory /var/www/html if it does not exist
   ansible.builtin.file:
     path: /var/www/html

--- a/ansible/roles/kms/tasks/main.yml
+++ b/ansible/roles/kms/tasks/main.yml
@@ -86,6 +86,22 @@
     group: root
     mode: "0644"
 
+- name: Create the directory /var/lib/cosmian_vm/data/app if it does not exist
+  ansible.builtin.file:
+    path: /var/lib/cosmian_vm/data/app
+    state: directory
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Create default Cosmian KMS configuration
+  ansible.builtin.template:
+    src: kms.toml.j2
+    dest: /var/lib/cosmian_vm/data/app/app.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Create the directory /var/www/html if it does not exist
   ansible.builtin.file:
     path: /var/www/html


### PR DESCRIPTION
Small Ansible modification concerning the kms and ai_runner roles in order to allow a functional KMS/AI runner image to be instantiated without having to do a `cosmian_vm app init` remotely.

For example, if we instantiate a Cosmian KMS, the KMS service uses a default conf (with a local redis database). The path of this configuration is the same as the path used by the service once we have done an app init (except that in this case, the configuration is not in a LUKS container).