### PR TITLE
feat: Upgrade Ubuntu 22.04 to 24.04 on Azure

### DIFF
--- a/.github/scripts/aws-new-instance.sh
+++ b/.github/scripts/aws-new-instance.sh
@@ -33,7 +33,7 @@ else
     AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240523.1" --query "Images[*].{ID:ImageId}" --output text)
   else
     # Redhat SEV
-    AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3" --query "Images[*].{ID:ImageId}" --output text)
+    AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=RHEL-9.4.0_HVM-20241210-x86_64-0-Hourly2-GP3" --query "Images[*].{ID:ImageId}" --output text)
   fi
 
   AMI=$(

--- a/.github/scripts/aws-packer-build.sh
+++ b/.github/scripts/aws-packer-build.sh
@@ -3,11 +3,11 @@
 # Only for testing, DO NOT UNCOMMENT
 # DISTRIBUTION=rhel
 # PRODUCT=cosmian-vm
-# VERSION=0.1.10 # Optional
-# KMS_VERSION=4.21.1 # Provided by Github workflow
+# VERSION=0.1.11 # Optional
+# KMS_VERSION=4.21.2 # Provided by Github workflow
 # AI_RUNNER_VERSION=0.3.0 # Provided by Github workflow
-# GITHUB_REF=refs/tags/1.3.2 # Provided by Github Actions
-# GITHUB_REF_NAME=1.3.2 # Provided by Github Actions
+# GITHUB_REF=refs/tags/1.3.3 # Provided by Github Actions
+# GITHUB_REF_NAME=1.3.3 # Provided by Github Actions
 # IMAGE_NAME="cosmian-vm-${GITHUB_REF_NAME}-sev-${DISTRIBUTION}" # Only for testing
 
 set -ex

--- a/.github/scripts/aws-packer-build.sh
+++ b/.github/scripts/aws-packer-build.sh
@@ -25,7 +25,7 @@ else
   if [ "$DISTRIBUTION" = "ubuntu" ]; then
     BASE_IMAGE_NAME="ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240523.1"
   else
-    BASE_IMAGE_NAME="RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3"
+    BASE_IMAGE_NAME="RHEL-9.4.0_HVM-20241210-x86_64-0-Hourly2-GP3"
   fi
 fi
 

--- a/.github/scripts/azure-create-vm-image-definition.sh
+++ b/.github/scripts/azure-create-vm-image-definition.sh
@@ -20,8 +20,8 @@ for product in "${products[@]}"; do
       name="${product}-${distrib}-${techno}"
 
       if [ "${distrib}" = "ubuntu" ]; then
-        offer=0001-com-ubuntu-confidential-vm-jammy
-        sku=22_04-lts-cvm
+        offer=ubuntu-24_04-lts
+        sku=cvm
       else
         offer=rhel-cvm
         sku=9_4_cvm

--- a/.github/scripts/azure-new-instance.sh
+++ b/.github/scripts/azure-new-instance.sh
@@ -18,7 +18,7 @@ if [ "$TECHNO" = "tdx" ]; then
     --name "$NAME" \
     --size Standard_DC2es_v5 \
     --enable-secure-boot true \
-    --image "Canonical:0001-com-ubuntu-confidential-vm-jammy:22_04-lts-cvm:latest" \
+    --image "Canonical:ubuntu-24_04-lts:cvm:latest" \
     --public-ip-sku Standard \
     --admin-username azureuser \
     --os-disk-delete-option delete \
@@ -27,13 +27,13 @@ if [ "$TECHNO" = "tdx" ]; then
     --security-type ConfidentialVM \
     --ssh-key-values "$SSH_PUB_KEY"
 else
-  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/base-image-${DISTRIB}-${TECHNO}/versions/0.1.10"
-  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/cosmian-vm-${DISTRIB}-${TECHNO}/versions/1.3.2"
-  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/kms-${DISTRIB}-${TECHNO}/versions/4.21.1"
+  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/kms-${DISTRIB}-${TECHNO}/versions/4.21.2"
+  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/cosmian-vm-${DISTRIB}-${TECHNO}/versions/1.3.3"
+  IMAGE_NAME="/subscriptions/bc07f5de-3498-43b8-94aa-34b4a34a89b8/resourceGroups/packer-snp/providers/Microsoft.Compute/galleries/cosmian_packer/images/base-image-${DISTRIB}-${TECHNO}/versions/0.1.11"
 
   if [ "$DISTRIB" = "ubuntu" ]; then
     # Ubuntu SEV
-    IMAGE_NAME="Canonical:0001-com-ubuntu-confidential-vm-jammy:22_04-lts-cvm:latest"
+    IMAGE_NAME="Canonical:ubuntu-24_04-lts:cvm:latest"
   else
     # Redhat SEV
     IMAGE_NAME="redhat:rhel-cvm:9_4_cvm:latest"

--- a/.github/scripts/azure-packer-build.sh
+++ b/.github/scripts/azure-packer-build.sh
@@ -9,8 +9,8 @@ set
 
 if [ "$DISTRIBUTION" = "ubuntu" ]; then
   IMAGE_PUBLISHER="canonical"
-  IMAGE_OFFER="0001-com-ubuntu-confidential-vm-jammy"
-  IMAGE_SKU="22_04-lts-cvm"
+  IMAGE_OFFER="ubuntu-24_04-lts"
+  IMAGE_SKU="cvm"
 else
   IMAGE_PUBLISHER="redhat"
   IMAGE_OFFER="rhel-cvm"

--- a/.github/scripts/gcp-new-instance.sh
+++ b/.github/scripts/gcp-new-instance.sh
@@ -38,25 +38,25 @@ if [ "$TECHNO" = "tdx" ]; then
 else
   if [ "$DISTRIB" = "ubuntu" ]; then
     # Base Ubuntu SEV
-    IMAGE="base-image-0-1-6-ubuntu-sev"
+    IMAGE="base-image-0-1-11-ubuntu-sev"
     IMAGE_PROJECT="cosmian-dev"
     # Cosmian Ubuntu SEV
-    IMAGE="cosmian-vm-1-2-6-sev-ubuntu"
+    IMAGE="cosmian-vm-1-3-3-sev-ubuntu"
+    IMAGE_PROJECT="cosmian-dev"
     # Cosmian KMS Ubuntu SEV
     IMAGE="cosmian-vm-1-3-3-kms-4-21-2-sev-ubuntu"
-    IMAGE_PROJECT="cosmian-dev"
     IMAGE_PROJECT="cosmian-dev"
     # Ubuntu SEV
     IMAGE="ubuntu-2404-noble-amd64-v20241004"
     IMAGE_PROJECT="ubuntu-os-cloud"
   else
-    # Base Ubuntu SEV
-    IMAGE="base-image-0-1-6-rhel-sev"
+    # Base RHEL SEV
+    IMAGE="base-image-0-1-11-rhel-sev"
     IMAGE_PROJECT="cosmian-dev"
-    # Cosmian Ubuntu SEV
-    IMAGE="cosmian-vm-1-2-6-rhel-sev"
+    # Cosmian RHEL SEV
+    IMAGE="cosmian-vm-1-3-3-rhel-sev"
     IMAGE_PROJECT="cosmian-dev"
-    # Cosmian Ubuntu SEV
+    # Cosmian RHEL SEV
     IMAGE="cosmian-vm-1-2-6-kms-4-17-0-sev-rhel"
     IMAGE_PROJECT="cosmian-dev"
     # RHEL SEV

--- a/.github/scripts/gcp-new-instance.sh
+++ b/.github/scripts/gcp-new-instance.sh
@@ -42,9 +42,9 @@ else
     IMAGE_PROJECT="cosmian-dev"
     # Cosmian Ubuntu SEV
     IMAGE="cosmian-vm-1-2-6-sev-ubuntu"
-    IMAGE_PROJECT="cosmian-dev"
     # Cosmian KMS Ubuntu SEV
-    IMAGE="cosmian-vm-1-2-6-kms-4-17-0-sev-ubuntu"
+    IMAGE="cosmian-vm-1-3-3-kms-4-21-2-sev-ubuntu"
+    IMAGE_PROJECT="cosmian-dev"
     IMAGE_PROJECT="cosmian-dev"
     # Ubuntu SEV
     IMAGE="ubuntu-2404-noble-amd64-v20241004"

--- a/.github/scripts/push_packages.sh
+++ b/.github/scripts/push_packages.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=1.3.2
+VERSION=1.3.3
 
 set -x
 if [[ "${GITHUB_REF}" =~ 'refs/tags/' ]]; then

--- a/.github/workflows/aws_ansible.yml
+++ b/.github/workflows/aws_ansible.yml
@@ -60,7 +60,7 @@ jobs:
           if [ "${{ inputs.distrib }}" = "ubuntu" ]; then
             export AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240523.1" --query "Images[*].{ID:ImageId}" --output text)
           else
-            export AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3" --query "Images[*].{ID:ImageId}" --output text)
+            export AMI_BASE=$(aws ec2 describe-images --filters "Name=name,Values=RHEL-9.4.0_HVM-20241210-x86_64-0-Hourly2-GP3" --query "Images[*].{ID:ImageId}" --output text)
           fi
 
           AMI=$(aws ec2 run-instances \

--- a/.github/workflows/azure_ansible.yml
+++ b/.github/workflows/azure_ansible.yml
@@ -57,7 +57,7 @@ jobs:
           set -ex
 
           if [ "${{ inputs.distrib }}" = "ubuntu" ]; then
-            IMAGE_TO_INSTANTIATE="Canonical:0001-com-ubuntu-confidential-vm-jammy:22_04-lts-cvm:latest"
+            IMAGE_TO_INSTANTIATE="Canonical:ubuntu-24_04-lts:cvm:latest"
           else
             IMAGE_TO_INSTANTIATE="redhat:rhel-cvm:9_4_cvm:latest"
           fi

--- a/.github/workflows/base_main.yml
+++ b/.github/workflows/base_main.yml
@@ -8,17 +8,17 @@ jobs:
   azure:
     uses: ./.github/workflows/base_azure_main.yml
     with:
-      base-version: 0.1.10
+      base-version: 0.1.11
     secrets: inherit
 
   gcp:
     uses: ./.github/workflows/base_gcp_main.yml
     with:
-      base-version: 0.1.10
+      base-version: 0.1.11
     secrets: inherit
 
   aws:
     uses: ./.github/workflows/base_aws_main.yml
     with:
-      base-version: 0.1.10
+      base-version: 0.1.11
     secrets: inherit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,13 @@ on:
 name: Pull request
 
 jobs:
+  cleanup: # we remove the Github cache to avoid any conflict
+    name: Clean Github cache
+    uses: Cosmian/reusable_workflows/.github/workflows/cleanup_cache.yml@main
+    secrets: inherit
+
   build-cosmian-vm-binaries:
+    needs: cleanup
     name: Build binaries
     uses: ./.github/workflows/build_all.yml
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/azure_main.yml
     with:
       product: cosmian-vm
-      kms-version: 4.21.1
+      kms-version: 4.21.2
       ai-runner-version: 0.3.0
       techno: sev
     secrets: inherit
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/gcp_main.yml
     with:
       product: cosmian-vm
-      kms-version: 4.21.1
+      kms-version: 4.21.2
       ai-runner-version: 0.3.0
       techno: sev
     secrets: inherit
@@ -36,7 +36,7 @@ jobs:
   #   uses: ./.github/workflows/aws_main.yml
   #   with:
   #     product: cosmian-vm
-  #     kms-version: 4.21.1
+  #     kms-version: 4.21.2
   #     ai-runner-version: 0.3.0
   #     techno: sev
   #   secrets: inherit

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -12,7 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  cleanup: # we remove the Github cache to avoid any conflict
+    name: Clean Github cache
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: Cosmian/reusable_workflows/.github/workflows/cleanup_cache.yml@main
+    secrets: inherit
+
   build-cosmian-vm-binaries:
+    needs: cleanup
     name: Build binaries
     uses: ./.github/workflows/build_all.yml
 
@@ -20,8 +27,8 @@ jobs:
     needs: build-cosmian-vm-binaries
     uses: ./.github/workflows/release_azure_main.yml
     with:
-      base-version: 0.1.10
-      kms-version: 4.21.1
+      base-version: 0.1.11
+      kms-version: 4.21.2
       ai-runner-version: 0.3.0
     secrets: inherit
 
@@ -29,8 +36,8 @@ jobs:
     needs: build-cosmian-vm-binaries
     uses: ./.github/workflows/release_gcp_main.yml
     with:
-      base-version: 0.1.10
-      kms-version: 4.21.1
+      base-version: 0.1.11
+      kms-version: 4.21.2
       ai-runner-version: 0.3.0
     secrets: inherit
 
@@ -38,8 +45,8 @@ jobs:
     needs: build-cosmian-vm-binaries
     uses: ./.github/workflows/release_aws_main.yml
     with:
-      base-version: 0.1.10
-      kms-version: 4.21.1
+      base-version: 0.1.11
+      kms-version: 4.21.2
       ai-runner-version: 0.3.0
     secrets: inherit
 

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   cleanup: # we remove the Github cache to avoid any conflict
     name: Clean Github cache
-    if: startsWith(github.ref, 'refs/tags/')
     uses: Cosmian/reusable_workflows/.github/workflows/cleanup_cache.yml@main
     secrets: inherit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - Revert changes on AI runner systemd service file ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+- *GCP RHEL*: Do not upgrade all RHEL packages - just refresh cache ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+- For releases, clean Github cache before anything
 
 ## [1.3.2] - 2025-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Upgrade the Cosmian base image v0.1.11 to upgrade Azure Ubuntu 22.04 to 24.04 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
 - Regenerate all images with the new base image v0.1.11 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
 - Bump KMS version from 4.21.1 to 4.21.2
+- *AWS RHEL*: Bump version to 9.4 (RHEL-9.4.0_HVM-20241210-x86_64-0-Hourly2-GP3)
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2025-01-27
+
+### 🚀 Features
+
+- Upgrade the Cosmian base image v0.1.11 to upgrade Azure Ubuntu 22.04 to 24.04 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+- Regenerate all images with the new base image v0.1.11 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+- Bump KMS version from 4.21.1 to 4.21.2
+
+### 🐛 Bug Fixes
+
+- Revert changes on AI runner systemd service file ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+
 ## [1.3.2] - 2025-01-18
 
 ### 🚀 Features

--- a/CHANGELOG_BASE_IMAGES.md
+++ b/CHANGELOG_BASE_IMAGES.md
@@ -1,5 +1,10 @@
 # Cosmian Base Image Changelog
 
+## [0.1.11] - 2025-01-27
+
+- *Azure*: ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
+  - Upgrade Ubuntu 22.04 to 24.04:
+
 ## [0.1.10] - 2024-10-10
 
 - *GCP*: ([#158](https://github.com/Cosmian/cosmian_vm/pull/158))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cosmian_certtool"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "acme-lib",
  "actix-files",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_vm"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "clap 4.5.7",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_vm_agent"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "cosmian_vm_client"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "ima"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "bincode",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 license = "BUSL-1.1"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Replace `X.Y.Z` in the 3 following tables by the last _Cosmian base image_ [vers
 |               |                            Official image                            | OS image | OS version | Kernel version               | Cosmian base image          |
 | :------------ | :------------------------------------------------------------------: | :------: | ---------- | ---------------------------- | --------------------------- |
 | AWS - AMD SEV | ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240523.1 |  Ubuntu  | 24.04      | 6.8.0-1016-aws               | base-image-X-Y-Z-ubuntu-sev |
-| AWS - AMD SEV |            RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3             |  Redhat  | 9.3        | 5.14.0-427.37.1.el9_4.x86_64 | base-image-X-Y-Z-ubuntu-sev |
+| AWS - AMD SEV |             RHEL-9.4.0_HVM-20241210-x86_64-0-Hourly2-GP3             |  Redhat  | 9.4        | 5.14.0-427.37.1.el9_4.x86_64 | base-image-X-Y-Z-ubuntu-sev |
 
 If needed:
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ aws ec2 describe-images --output json > aws_list.json
 
 ### Azure images
 
-|                   |                        Official image                         | OS image | OS version      | Kernel version               | Cosmian base image    | Version |
-| :---------------- | :-----------------------------------------------------------: | :------: | --------------- | ---------------------------- | --------------------- | ------- |
-| Azure - Intel TDX | Canonical-0001-com-ubuntu-confidential-vm-jammy-22_04-lts-cvm |  Ubuntu  | 22.04.202404090 | 6.5.0-1025-azure             | base-image-ubuntu-tdx | X.Y.Z   |
-| Azure - AMD SEV   | Canonical-0001-com-ubuntu-confidential-vm-jammy-22_04-lts-cvm |  Ubuntu  | 22.04.202404090 | 6.5.0-1025-azure             | base-image-ubuntu-sev | X.Y.Z   |
-| Azure - Intel TDX |                    Redhat-rhel-cvm-9_4_cvm                    |  Redhat  | 9.4             | 5.14.0-427.37.1.el9_4.x86_64 | base-image-rhel-tdx   | X.Y.Z   |
-| Azure - AMD SEV   |                    Redhat-rhel-cvm-9_4_cvm                    |  Redhat  | 9.4             | 5.14.0-427.37.1.el9_4.x86_64 | base-image-rhel-sev   | X.Y.Z   |
+|                   |         Official image         | OS image | OS version      | Kernel version               | Cosmian base image    | Version |
+| :---------------- | :----------------------------: | :------: | --------------- | ---------------------------- | --------------------- | ------- |
+| Azure - Intel TDX | Canonical-ubuntu-24_04-lts-cvm |  Ubuntu  | 22.04.202404090 | 6.8.0-1020-azure             | base-image-ubuntu-tdx | X.Y.Z   |
+| Azure - AMD SEV   | Canonical-ubuntu-24_04-lts-cvm |  Ubuntu  | 22.04.202404090 | 6.8.0-1020-azure             | base-image-ubuntu-sev | X.Y.Z   |
+| Azure - Intel TDX |    Redhat-rhel-cvm-9_4_cvm     |  Redhat  | 9.4             | 5.14.0-427.37.1.el9_4.x86_64 | base-image-rhel-tdx   | X.Y.Z   |
+| Azure - AMD SEV   |    Redhat-rhel-cvm-9_4_cvm     |  Redhat  | 9.4             | 5.14.0-427.37.1.el9_4.x86_64 | base-image-rhel-sev   | X.Y.Z   |
 
 ```sh
 az vm image list --all > azure_list.json
@@ -345,6 +345,7 @@ cosmian_vm --url https://my_app.dev app restart
 
 | Base image | Cosmian VM | Cosmian KMS | Cosmian AI Runner |
 | ---------- | ---------- | ----------- | ----------------- |
+| 0.1.11     | 1.3.3      | 4.21.2      | 0.3.0             |
 | 0.1.10     | 1.3.2      | 4.21.1      | 0.3.0             |
 | 0.1.10     | 1.3.1      | 4.19.3      | 0.3.0             |
 | 0.1.10     | 1.3.0      | 4.19.1      | 0.3.0             |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ To proceed a new release, please follow the steps below:
    - Replace all old version numbers of the Cosmian Base VM image in:
      - `base_main.yml`
      - `release_main.yml`
-   - Commit the changes: `git commit -am "chore: create new Cosmian Base Image version" && git push`
+   - Commit the changes: `git commit -am "chore: create new Cosmian Base Image version X.Y.Z" && git push`
    - Eventually discard the pipelines related to the last commit.
    - Run manually the workflow [Manual base images recreation](https://github.com/Cosmian/cosmian_vm/actions/workflows/base_main.yml)
      - Run workflow on branch `release/X.Y.Z`
@@ -30,10 +30,10 @@ To proceed a new release, please follow the steps below:
    - Increase the version number in the [CHANGELOG.md](CHANGELOG.md) file.
    - Increase the version number in the [README.md](README.md) file, Section `Versions correspondence`.
    - Increase the version number in the [cargo.toml root file](Cargo.toml).
-   - Do a cargo build a the root of the project to update the Cargo.lock file. In particular, in these 2 files:
+   - Do a cargo build a the root of the project to update the Cargo.lock file.
+   - Replace everywhere old version numbers of the Cosmian VM image. In particular, in these 2 files:
      - `pull_request.yml`
      - `release_main.yml`
-   - Replace everywhere old version numbers of the Cosmian VM image.
    - Once the CI pipeline is green, merge it into the `main` branch.
    - Next, create a final tag to launch the release pipeline which will publish the Cosmian VM images on the marketplaces:
      - `git tag X.Y.Z -m "fix: this is why we did a new version"`

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,8 +1,8 @@
 ---
-cosmian_vm_version: 1.3.2
-package_version: 1.3.2
-cosmian_kms_version: 4.21.1
-kms_package_version: 4.21.1
+cosmian_vm_version: 1.3.3
+package_version: 1.3.3
+cosmian_kms_version: 4.21.2
+kms_package_version: 4.21.2
 cosmian_ai_runner_version: 0.3.0
 
 nginx_user: root

--- a/ansible/roles/ai_runner/templates/cosmian_ai_runner.service.j2
+++ b/ansible/roles/ai_runner/templates/cosmian_ai_runner.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Cosmian AI Runner
-Requires=multi-user.target cosmian_vm_agent.service
-After=multi-user.target cosmian_vm_agent.service
+Requires=multi-user.target
+After=multi-user.target mount_luks.service cosmian_vm_agent.service
 
 [Service]
 Type=simple

--- a/ansible/roles/ai_runner/templates/cosmian_ai_runner.service.j2
+++ b/ansible/roles/ai_runner/templates/cosmian_ai_runner.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Cosmian AI Runner
-Requires=multi-user.target
-After=multi-user.target mount_luks.service cosmian_vm_agent.service
+Requires=multi-user.target cosmian_vm_agent.service
+After=multi-user.target cosmian_vm_agent.service
 
 [Service]
 Type=simple

--- a/ansible/roles/check_app/tasks/main.yml
+++ b/ansible/roles/check_app/tasks/main.yml
@@ -32,6 +32,7 @@
   ansible.builtin.wait_for:
     path: /var/lib/cosmian_vm/data/cert.pem
     state: present
+    timeout: 600 # default is 300
 
 - name: Check if port 5555 is listening
   ansible.builtin.wait_for:

--- a/ansible/roles/check_cosmian_vm/tasks/main.yml
+++ b/ansible/roles/check_cosmian_vm/tasks/main.yml
@@ -51,6 +51,7 @@
   ansible.builtin.wait_for:
     path: /var/lib/cosmian_vm/data/cert.pem
     state: present
+    timeout: 600 # default is 300
 
 - name: Display Cosmian VM Agent version
   ansible.builtin.debug:
@@ -203,6 +204,7 @@
       ansible.builtin.wait_for:
         path: /var/lib/cosmian_vm/data/cert.pem
         state: present
+        timeout: 600 # default is 300
 
     - name: Check if port 5555 is listening
       ansible.builtin.wait_for:

--- a/ansible/roles/upgrade/tasks/main.yml
+++ b/ansible/roles/upgrade/tasks/main.yml
@@ -31,14 +31,6 @@
         state: present
         update_cache: true
 
-    - name: Update all packages
-      ansible.builtin.dnf:
-        name: "*"
-        state: latest
-        update_only: true
-        update_cache: true
-      tags: redhat
-
     - name: Update security packages
       ansible.builtin.dnf:
         security: true

--- a/pkg/cosmian_vm_agent.service
+++ b/pkg/cosmian_vm_agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Cosmian VM Agent
 Requires=multi-user.target
-After=multi-user.target mount_luks.service dev-tpm0.device
+After=multi-user.target mount_luks.service
 
 [Service]
 Type=simple

--- a/pkg/mount_luks.service
+++ b/pkg/mount_luks.service
@@ -4,7 +4,7 @@ Requires=multi-user.target
 After=multi-user.target
 
 [Service]
-Type=oneshot
+Type=exec
 ExecStart=/bin/bash /root/mount_luks.sh
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
## [1.3.3] - 2025-01-27

### 🚀 Features

- Upgrade the Cosmian base image v0.1.11 to upgrade Azure Ubuntu 22.04 to 24.04 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
- Regenerate all images with the new base image v0.1.11 ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
- Bump KMS version from 4.21.1 to 4.21.2

### 🐛 Bug Fixes

- Revert changes on AI runner systemd service file ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
- *GCP RHEL*: Do not upgrade all RHEL packages - just refresh cache ([#168](https://github.com/Cosmian/cosmian_vm/pull/168))
- For releases, clean Github cache before anything