### PR TITLE
Use detached header for LUKS container

### DIFF
--- a/ansible/roles/check_cosmian_vm/tasks/main.yml
+++ b/ansible/roles/check_cosmian_vm/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: Before any check - LUKS dump
   ansible.builtin.command:
     cmd: |
-      cryptsetup luksDump /var/lib/cosmian_vm/container
+      cryptsetup luksDump /var/lib/cosmian_vm/header
   register: check_cosmian_vm_cryptsetup_luks_dump
   changed_when: check_cosmian_vm_cryptsetup_luks_dump.rc != 0
   tags: check_cosmian_vm_cryptsetup_luks_dump

--- a/pkg/cosmian_fstool
+++ b/pkg/cosmian_fstool
@@ -32,6 +32,7 @@ set_default_variables() {
     # Optional args
     DEFAULT_ROOT="/var/lib/cosmian_vm"
     CONTAINER_PATH="$DEFAULT_ROOT/container"
+    HEADER_PATH="$DEFAULT_ROOT/header"
     CONTAINER_MAPPING_NAME="cosmian_vm_container"
     CONTAINER_MAPPING_PATH="/dev/mapper/$CONTAINER_MAPPING_NAME"
     CONTAINER_MOUNT_PATH="$DEFAULT_ROOT/data"
@@ -95,6 +96,11 @@ if [ -e "$CONTAINER_PATH" ]; then
     exit 1
 fi
 
+if [ -e "$HEADER_PATH" ]; then
+    echo "A LUKS header already exists in $HEADER_PATH (remove it before going any further)"
+    exit 1
+fi
+
 # Make sure to close/umount existing container
 if [ -e "$CONTAINER_MAPPING_PATH" ]; then
     echo "Closing previous mounted container..."
@@ -109,11 +115,11 @@ fallocate -l "$CONTAINER_SIZE" "$CONTAINER_PATH"
 
 # Encrypt the container (a password is required to run this command)
 echo "Encrypting the container (with password=${PASSWORD})..."
-echo -n "$PASSWORD" | cryptsetup luksFormat "$CONTAINER_PATH" -d -
+echo -n "$PASSWORD" | cryptsetup luksFormat "$CONTAINER_PATH" --header "$HEADER_PATH" --key-file -
 
 # Open the container and map it (a password is required to run this command)
 echo "Opening the container at $CONTAINER_MAPPING_PATH..."
-echo -n "$PASSWORD" | cryptsetup luksOpen -d - "$CONTAINER_PATH" "$CONTAINER_MAPPING_NAME"
+echo -n "$PASSWORD" | cryptsetup luksOpen --header "$HEADER_PATH" --key-file - "$CONTAINER_PATH" "$CONTAINER_MAPPING_NAME"
 
 # Format it
 echo "Formatting the container in Ext4..."
@@ -137,16 +143,17 @@ fi
 echo "Enrolling the TPM for this container on block device $BLOCK_DEVICE..."
 
 set +e
-PASSWORD=$PASSWORD systemd-cryptenroll --tpm2-device=auto --wipe-slot=tpm2 "$BLOCK_DEVICE"
+PASSWORD=$PASSWORD systemd-cryptenroll --tpm2-device=auto --wipe-slot=tpm2 "$HEADER_PATH"
 if [ $? -ne 0 ]; then
     # Need to clean container after failure
     rm -f "$CONTAINER_PATH"
+    rm -f "$HEADER_PATH"
     exit 1
 fi
 
 # Display debug information
 set -x
-cryptsetup luksDump $CONTAINER_PATH
+cryptsetup luksDump "$HEADER_PATH"
 set +x
 
 echo "Process completed with success!"

--- a/pkg/cosmian_fstool
+++ b/pkg/cosmian_fstool
@@ -115,7 +115,7 @@ fallocate -l "$CONTAINER_SIZE" "$CONTAINER_PATH"
 
 # Encrypt the container (a password is required to run this command)
 echo "Encrypting the container (with password=${PASSWORD})..."
-echo -n "$PASSWORD" | cryptsetup luksFormat "$CONTAINER_PATH" --header "$HEADER_PATH" --key-file -
+echo -n "$PASSWORD" | cryptsetup luksFormat "$CONTAINER_PATH" --type luks2 --integrity hmac-sha256 --header "$HEADER_PATH" --key-file -
 
 # Open the container and map it (a password is required to run this command)
 echo "Opening the container at $CONTAINER_MAPPING_PATH..."

--- a/pkg/mount_luks.sh
+++ b/pkg/mount_luks.sh
@@ -16,7 +16,7 @@ case $? in
 # failure; the directory is not a mountpoint, or device is not a block device on --devno
 32)
     # unlock the partition
-    /lib/systemd/systemd-cryptsetup attach cosmian_vm_container /var/lib/cosmian_vm/container - tpm2-device=auto,headless=true || exit 1
+    /lib/systemd/systemd-cryptsetup attach cosmian_vm_container /var/lib/cosmian_vm/container - tpm2-device=auto,headless=true,header=/var/lib/cosmian_vm/header || exit 1
     # mount the partition
     mount /dev/mapper/cosmian_vm_container /var/lib/cosmian_vm/data || exit 1
     exit 0

--- a/pkg/mount_luks.sh
+++ b/pkg/mount_luks.sh
@@ -15,6 +15,21 @@ case $? in
     ;;
 # failure; the directory is not a mountpoint, or device is not a block device on --devno
 32)
+    LUKS_DUMP=$(cryptsetup luksDump --dump-json-metadata /var/lib/cosmian_vm/header)
+    STATUS=$?
+
+    if [ $STATUS -ne 0 ]; then
+        echo "LUKS header does not exist"
+        exit 2
+    fi
+
+    NULL_CIPHERS=$(echo "$LUKS_DUMP" | jq '[.keyslots.[].area.encryption] | select(any(contains("null")))')
+
+    if [ -n "$NULL_CIPHERS" ]; then
+        echo "cipher_null is not allowed in LUKS header"
+        exit 3
+    fi 
+
     # unlock the partition
     /lib/systemd/systemd-cryptsetup attach cosmian_vm_container /var/lib/cosmian_vm/container - tpm2-device=auto,headless=true,header=/var/lib/cosmian_vm/header || exit 1
     # mount the partition

--- a/pkg/mount_luks.sh
+++ b/pkg/mount_luks.sh
@@ -26,9 +26,16 @@ case $? in
     NULL_CIPHERS=$(echo "$LUKS_DUMP" | jq '[.keyslots.[].area.encryption] | select(any(contains("null")))')
 
     if [ -n "$NULL_CIPHERS" ]; then
-        echo "cipher_null is not allowed in LUKS header"
+        echo "cipher_null in keyslots is not allowed in LUKS header"
         exit 3
-    fi 
+    fi
+
+    NULL_CIPHERS=$(echo "$LUKS_DUMP" | jq '[.segments.[].encryption] | select(any(contains("null")))')
+
+    if [ -n "$NULL_CIPHERS" ]; then
+        echo "cipher_null in segments is not allowed in LUKS header"
+        exit 4
+    fi
 
     # unlock the partition
     /lib/systemd/systemd-cryptsetup attach cosmian_vm_container /var/lib/cosmian_vm/container - tpm2-device=auto,headless=true,header=/var/lib/cosmian_vm/header || exit 1


### PR DESCRIPTION
Thanks to @tjade273 of the @trailofbits team for reporting the following security issue:

## Summary

A malicious host may provide a crafted LUKS2 volume to a Cosmian VM guest that uses TPM‑assisted unlocking. The guest will open the volume using its legitimate passphrase or TPM token, but due to unauthenticated LUKS2 metadata the data cipher for the volume can be set to a null cipher. Guest writes are then stored in a form recoverable by the host. The host can also pre‑load arbitrary data in the container, potentially influencing guest execution.

## Background

LUKS2 protects a randomly generated master key. Copies of this master key are stored in one or more “keyslots,” each wrapped by a user credential (for example, a passphrase or a TPM‑bound key). When the credential is provided, the corresponding keyslot is decrypted to recover the master key. Separately, the LUKS2 header also specifies how data on the volume is encrypted (the “segment” or volume cipher, such as aes-xts-plain64).

Prior to cryptsetup 2.8.1, it was possible to use a null cipher in keyslot encryption so that any passphrase appeared to succeed. Cryptsetup 2.8.1 disables null ciphers in keyslot encryption when a user credential is non‑empty, which prevents that specific bypass. However, LUKS2 metadata is not authenticated, so a host controlling the header can still modify the data‑at‑rest parameters (the segment/volume cipher) without altering the valid keyslots. In that case, the disk will open only with the original passphrase/token, but once opened the volume can use a null data cipher, making new writes readable by the host.

## Details

Cosmian VM uses a LUKS2‑encrypted container as persistent storage at `/var/lib/cosmian_vm/container`, mounted at `/var/lib/cosmian_vm/data`.

- `pkg/mount_luks.sh` unlocks and maps the container using:
    - `/lib/systemd/systemd-cryptsetup attach cosmian_vm_container /var/lib/cosmian_vm/container - tpm2-device=auto,headless=true`
    - If attach succeeds, the device is mounted without additional header validation.
    - Code: https://github.com/Cosmian/cosmian_vm/blob/HEAD/pkg/mount_luks.sh
- `pkg/cosmian_fstool` provisions containers via `cryptsetup luksFormat` and `cryptsetup luksOpen`, then formats and mounts them.
    - Code: https://github.com/Cosmian/cosmian_vm/blob/HEAD/pkg/cosmian_fstool
- `crate/agent/src/init/luks.rs` can auto‑generate a container on first boot and writes the generated password into `/var/lib/cosmian_vm/data/luks_password`.
    - Code: https://github.com/Cosmian/cosmian_vm/blob/HEAD/crate/agent/src/init/luks.rs

## Impact

- Confidentiality: Secrets written into the LUKS container can be read by the host after opening the device with the valid credential and a null data cipher in effect.
- Integrity/Influence: The host can pre‑seed the container with arbitrary data, potentially affecting application behavior once the VM mounts and consumes it.

## Detection 

- Inspect LUKS2 headers for null/invalid ciphers in the data segments (the volume cipher), not just in keyslots. For example:
```
sudo cryptsetup luksDump --dump-json-metadata /var/lib/cosmian_vm/container \
  | grep -Ei '"cipher"\s*:\s*"(null|cipher_null|.*null.*)'
```

- Operators using the Cosmian Ansible role can also review the LUKS dump printed by the role:
Code: https://github.com/Cosmian/cosmian_vm/blob/HEAD/ansible/roles/check_cosmian_vm/tasks/main.yml

## Recommandations

- Use cryptsetup 2.8.1 or later, and add defense‑in‑depth validation before mounting:
    - Parse `luksDump --dump-json-metadata` and reject containers whose segment/volume cipher is null or outside an allowlist (for example, `aes-xts-plain64`).
    - Validate additional header fields to guard against downgrade or reencryption triggers.
- Reduce header attack surface with detached headers:
    - Use LUKS detached header mode with the header stored in tmpfs (RAM) and a persistent, authenticated copy protected by a MAC derived from the passphrase/TPM‑bound secret. Only accept headers that authenticate correctly.
- Where suitable, combine encryption with integrity (for example, dm‑integrity or dm‑verity) to provide tamper evidence and stronger policy enforcement.