### PR TITLE
CI: checkout tee-tools locally and patch Cargo.toml for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Cosmian/tee-tools
-          path: tee-tools
+          path: ${{ github.workspace }}/tee-tools
 
       - name: Patch Cargo.toml to use local tee-tools
         id: patch-tee-tools
         run: |
-          TEE_SHA=$(git -C tee-tools rev-parse --short HEAD)
+          TEE_SHA=$(git -C ${{ github.workspace }}/tee-tools rev-parse --short HEAD)
           echo "sha=${TEE_SHA}" >> $GITHUB_OUTPUT
           cat >> Cargo.toml << 'EOF'
 
           [patch."https://github.com/Cosmian/tee-tools"]
-          ratls = { path = "tee-tools/crate/ratls" }
-          tee_attestation = { path = "tee-tools/crate/tee_attestation" }
-          tpm_quote = { path = "tee-tools/crate/tpm_quote" }
+          ratls = { path = "${{ github.workspace }}/tee-tools/crate/ratls" }
+          tee_attestation = { path = "${{ github.workspace }}/tee-tools/crate/tee_attestation" }
+          tpm_quote = { path = "${{ github.workspace }}/tee-tools/crate/tpm_quote" }
           EOF
 
       - name: Cache dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,22 +22,20 @@ jobs:
           sudo chown -R $USER /lib/x86_64-linux-gnu/
 
       - name: Checkout tee-tools
-        uses: actions/checkout@v4
-        with:
-          repository: Cosmian/tee-tools
-          path: ${{ github.workspace }}/tee-tools
+        run: |
+          git clone --depth 1 https://github.com/Cosmian/tee-tools.git "$RUNNER_TEMP/tee-tools"
 
       - name: Patch Cargo.toml to use local tee-tools
         id: patch-tee-tools
         run: |
-          TEE_SHA=$(git -C ${{ github.workspace }}/tee-tools rev-parse --short HEAD)
+          TEE_SHA=$(git -C "$RUNNER_TEMP/tee-tools" rev-parse --short HEAD)
           echo "sha=${TEE_SHA}" >> $GITHUB_OUTPUT
-          cat >> Cargo.toml << 'EOF'
+          cat >> Cargo.toml << EOF
 
           [patch."https://github.com/Cosmian/tee-tools"]
-          ratls = { path = "${{ github.workspace }}/tee-tools/crate/ratls" }
-          tee_attestation = { path = "${{ github.workspace }}/tee-tools/crate/tee_attestation" }
-          tpm_quote = { path = "${{ github.workspace }}/tee-tools/crate/tpm_quote" }
+          ratls = { path = "$RUNNER_TEMP/tee-tools/crate/ratls" }
+          tee_attestation = { path = "$RUNNER_TEMP/tee-tools/crate/tee_attestation" }
+          tpm_quote = { path = "$RUNNER_TEMP/tee-tools/crate/tpm_quote" }
           EOF
 
       - name: Cache dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Cosmian/tee-tools
-          path: ../tee-tools
+          path: tee-tools
 
       - name: Patch Cargo.toml to use local tee-tools
         id: patch-tee-tools
         run: |
-          TEE_SHA=$(git -C ../tee-tools rev-parse --short HEAD)
+          TEE_SHA=$(git -C tee-tools rev-parse --short HEAD)
           echo "sha=${TEE_SHA}" >> $GITHUB_OUTPUT
           cat >> Cargo.toml << 'EOF'
 
           [patch."https://github.com/Cosmian/tee-tools"]
-          ratls = { path = "../tee-tools/crate/ratls" }
-          tee_attestation = { path = "../tee-tools/crate/tee_attestation" }
-          tpm_quote = { path = "../tee-tools/crate/tpm_quote" }
+          ratls = { path = "tee-tools/crate/ratls" }
+          tee_attestation = { path = "tee-tools/crate/tee_attestation" }
+          tpm_quote = { path = "tee-tools/crate/tpm_quote" }
           EOF
 
       - name: Cache dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,30 @@ jobs:
         run: |
           sudo chown -R $USER /lib/x86_64-linux-gnu/
 
+      - name: Checkout tee-tools
+        uses: actions/checkout@v4
+        with:
+          repository: Cosmian/tee-tools
+          path: ../tee-tools
+
+      - name: Patch Cargo.toml to use local tee-tools
+        id: patch-tee-tools
+        run: |
+          TEE_SHA=$(git -C ../tee-tools rev-parse --short HEAD)
+          echo "sha=${TEE_SHA}" >> $GITHUB_OUTPUT
+          cat >> Cargo.toml << 'EOF'
+
+          [patch."https://github.com/Cosmian/tee-tools"]
+          ratls = { path = "../tee-tools/crate/ratls" }
+          tee_attestation = { path = "../tee-tools/crate/tee_attestation" }
+          tpm_quote = { path = "../tee-tools/crate/tpm_quote" }
+          EOF
+
       - name: Cache dependencies
         id: cargo-cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.distrib }}-${{ github.ref_name }}
+          key: ${{ inputs.distrib }}-${{ github.ref_name }}-${{ steps.patch-tee-tools.outputs.sha }}
           cache-directories: |
             - /usr/lib/x86_64-linux-gnu/libtdx_attest.so.1.24.100.2
 

--- a/crate/agent/src/worker/snapshot.rs
+++ b/crate/agent/src/worker/snapshot.rs
@@ -228,7 +228,7 @@ pub async fn hash_filesystem(hash_method: &ImaHashMethod) -> Result<Vec<(String,
 
     // Create threads to compute the hash in parallel
     // Note: processing like that doesn't block the main thread when stopping
-    Ok(futures::stream::iter(files.into_iter())
+    Ok(futures::stream::iter(files)
         .map(|file| {
             async move {
                 hash_file(&file, hash_method)


### PR DESCRIPTION
## Context

`cosmian_vm` depends on three crates from `tee-tools` (`ratls`, `tee_attestation`, `tpm_quote`), currently pinned to tag `1.6.2` in `Cargo.toml`.

## Changes

In `build.yml`:

1. **Checkout `tee-tools`** — clones `Cosmian/tee-tools` (branch `main`) into `../tee-tools` before building, so it sits at the same relative path as in local development.

2. **Patch `Cargo.toml` at build time** — appends a `[patch."https://github.com/Cosmian/tee-tools"]` section pointing to local `path` dependencies. This is done without modifying the committed `Cargo.toml`.

3. **Cache key includes `tee-tools` SHA** — the Rust cache key is enriched with the short SHA of `tee-tools/main`, so the cache is automatically invalidated when `tee-tools` changes.

## Effect

Binaries (`cosmian_vm_agent`, `cosmian_vm` CLI) are compiled with the latest `tee-tools/main` code, pushed to `package.cosmian.com`, and then used by the Ansible integration tests on real SEV-SNP/TDX VMs (AWS, GCP, Azure).

If `tee-tools/main` is broken or incompatible, the CI build fails and blocks the integration tests.